### PR TITLE
Fix course RSS link not being imported

### DIFF
--- a/src/modules/degrees.ts
+++ b/src/modules/degrees.ts
@@ -205,6 +205,14 @@ export function provideCommands(): CommandDescriptor[] {
 					.setDescription("The acronym of the degree to refresh")
 					.setRequired(true)
 			)
+			.addBooleanOption(
+				new Builders.SlashCommandBooleanOption()
+					.setName("delete-orphans")
+					.setDescription(
+						"Delete courses that no longer belong to this degree"
+					)
+					.setRequired(false)
+			)
 	);
 	return [{ builder: cmd, handler: handleCommand }];
 }
@@ -702,6 +710,9 @@ export async function handleCommand(
 		case "refresh-courses": {
 			try {
 				const acronym = interaction.options.getString("acronym", true);
+				const deleteOrphans =
+					interaction.options.getBoolean("delete-orphans", false) ??
+					true;
 
 				const degree = await prisma.degree.findUnique({
 					where: { acronym },
@@ -716,11 +727,11 @@ export async function handleCommand(
 				await courses.importCoursesFromDegree(
 					prisma,
 					degree.fenixId,
-					true
+					deleteOrphans
 				);
 
 				logger.info(
-					{ acronym },
+					{ acronym, deleteOrphans },
 					"Refreshed degree's courses from Fénix"
 				);
 				await interaction.editReply(

--- a/src/modules/fenix.ts
+++ b/src/modules/fenix.ts
@@ -120,7 +120,7 @@ export async function getDegreeCourses(
 					.map((_, linkNode) => {
 						const executionCourseLink = $coursePage(linkNode)
 							.attr("href")
-							?.match(/\/disciplinas\/\w+\/([\w-]+)\/[\w-]+/);
+							?.match(/\/disciplinas\/[\w-]+\/([\w-]+)\/[\w-]+/);
 						if (
 							!executionCourseLink ||
 							executionCourseLink[1] !== academicYear

--- a/src/modules/rss.ts
+++ b/src/modules/rss.ts
@@ -120,6 +120,7 @@ async function sendAnnouncementMessage(
 			authorName,
 			content,
 			courseName: course.course.name,
+			channel,
 		},
 		"Sending course announcement"
 	);


### PR DESCRIPTION
Due to incorrect regex, courses that had a dash (-) in the name had an empty announcements RSS URL.

This PR fixes the regex, as well as improving the import process for the courses.