### PR TITLE
fix: remove unique constraint from course name

### DIFF
--- a/src/prisma/migrations/20250606110101_remove_unique_from_course_name/migration.sql
+++ b/src/prisma/migrations/20250606110101_remove_unique_from_course_name/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "courses_name_key";

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -75,7 +75,7 @@ model Course {
   acronym                  String         @id
   /// e.g., fp > fprog
   displayAcronym           String         @unique @map("display_acronym")
-  name                     String         @unique
+  name                     String
   channelId                String?        @unique @map("channel_id")
   roleId                   String?        @unique @map("role_id")
   hideChannel              Boolean        @default(false) @map("hide_channel")


### PR DESCRIPTION
Apparently it is possible for two courses to have the same name and different acronyms.